### PR TITLE
feat: [PIDM-504] update deploy config

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -5,7 +5,7 @@ version: 0.112.0
 appVersion: 0.2.9
 dependencies:
   - name: microservice-chart
-    version: 7.5.0
+    version: 8.0.2
     repository: "https://pagopa.github.io/aks-microservice-chart-blueprint"
     alias: functions
 #  - name: microservice-chart

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -18,8 +18,14 @@ microservice-chart: &microservice-chart
     initialDelaySeconds: 30
     periodSeconds: 30
     failureThreshold: 10
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
   deployment:
     create: true
+    replicas: 1 # (default) same as HPA minReplica
   serviceMonitor:
     create: true
     endpoints:

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -18,14 +18,14 @@ microservice-chart: &microservice-chart
     initialDelaySeconds: 30
     periodSeconds: 30
     failureThreshold: 10
-  strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxUnavailable: 0
-      maxSurge: 1
   deployment:
     create: true
     replicas: 1 # (default) same as HPA minReplica
+    strategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxUnavailable: 0
+        maxSurge: 1
   serviceMonitor:
     create: true
     endpoints:

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -18,8 +18,14 @@ microservice-chart: &microservice-chart
     initialDelaySeconds: 30
     periodSeconds: 30
     failureThreshold: 10
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
   deployment:
     create: true
+    replicas: 1 # (default) same as HPA minReplica
   serviceMonitor:
     create: true
     endpoints:

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -18,14 +18,14 @@ microservice-chart: &microservice-chart
     initialDelaySeconds: 30
     periodSeconds: 30
     failureThreshold: 10
-  strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxUnavailable: 0
-      maxSurge: 1
   deployment:
     create: true
     replicas: 1 # (default) same as HPA minReplica
+    strategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxUnavailable: 0
+        maxSurge: 1
   serviceMonitor:
     create: true
     endpoints:

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -18,8 +18,14 @@ microservice-chart: &microservice-chart
     initialDelaySeconds: 30
     periodSeconds: 30
     failureThreshold: 10
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
   deployment:
     create: true
+    replicas: 1 # (default) same as HPA minReplica
   serviceMonitor:
     create: true
     endpoints:

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -18,14 +18,14 @@ microservice-chart: &microservice-chart
     initialDelaySeconds: 30
     periodSeconds: 30
     failureThreshold: 10
-  strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxUnavailable: 0
-      maxSurge: 1
   deployment:
     create: true
     replicas: 1 # (default) same as HPA minReplica
+    strategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxUnavailable: 0
+        maxSurge: 1
   serviceMonitor:
     create: true
     endpoints:


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

- upgraded helm chart to v8.0.2
- added rolling update strategy (maxUnavailable, maxSurge)
- overridden deployment replicas to match HPA minReplica config

NOTE: upgraded in

- DEV -> OK
- UAT -> OK
- PROD -> OK

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This upgrade was required to address an issue with the rollout strategy and the autoscaler behaviour, where the pods would scale down to 1 during deploy instead of keeping the same number of pods and doing +1 -1 to avoid traffic congestion. Also replicas are set to match the autoscaling config during deploy, to avoid starting the service with 1 pod when there is relevant traffic on the service.
This also ensures zero-downtime deployments by keeping all existing pods running until new versions are healthy and ready, then replacing them one at a time.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

```
❯ helm dependency update
Getting updates for unmanaged Helm repositories...
...Successfully got an update from the "https://pagopa.github.io/aks-microservice-chart-blueprint" chart repository
Hang tight while we grab the latest from your chart repositories...
...Successfully got an update from the "bitnami" chart repository
Update Complete. ⎈Happy Helming!⎈
Saving 1 charts
Downloading microservice-chart from repo https://pagopa.github.io/aks-microservice-chart-blueprint
Deleting outdated charts
```

**VERY IMPORTANT**
The script needs to be adapted for every service and launched on each environment before actually upgrading through helm upgrade (ref. https://github.com/pagopa/aks-microservice-chart-blueprint/blob/main/scripts/migrate_from_v7_to_v8.sh)


```
❯ ../../migrate_from_v7_to_v8.sh pagopa-fdr-json-to-xml-functions pagopa-fdr-json-to-xml fdr
scaledobject.keda.sh/pagopa-fdr-json-to-xml-functions not labeled
scaledobject.keda.sh/pagopa-fdr-json-to-xml-functions not labeled
scaledobject.keda.sh/pagopa-fdr-json-to-xml-functions annotated
scaledobject.keda.sh/pagopa-fdr-json-to-xml-functions annotated
```
``` 
❯ kubectl get scaledobject pagopa-fdr-json-to-xml-functions -n fdr -o jsonpath='{.metadata.labels}' | jq
{
  "app.kubernetes.io/instance": "pagopa-fdr-json-to-xml",
  "app.kubernetes.io/managed-by": "Helm",
  "app.kubernetes.io/name": "functions",
  "app.kubernetes.io/version": "0.2.9",
  "azure.workload.identity/use": "true",
  "canaryDelivery": "false",
  "helm.sh/blueprint-version": "7.5.0",
  "helm.sh/chart": "functions-0.2.9",
  "scaledobject.keda.sh/name": "pagopa-fdr-json-to-xml-functions"
}
```
```
❯ kubectl get scaledobject pagopa-fdr-json-to-xml-functions -n fdr -o jsonpath='{.metadata.annotations}' | jq
{
  "helm.sh/hook": "post-install ,post-upgrade",
  "meta.helm.sh/release-name": "pagopa-fdr-json-to-xml",
  "meta.helm.sh/release-namespace": "fdr"
}
```
```
❯ kubectl delete scaledobject pagopa-fdr-json-to-xml-functions -n fdr
scaledobject.keda.sh "pagopa-fdr-json-to-xml-functions" deleted from fdr namespace
```
```
❯ helm upgrade --namespace fdr \
    --install --values ./values-dev.yaml \
    --set functions.azure.workloadIdentityClientId=edaa7974-xxxxx \
    --set functions.podAnnotations.force-rollout="rollout-$(date +%s)" \
    --wait --timeout 15m0s \
    pagopa-fdr-json-to-xml .
Release "pagopa-fdr-json-to-xml" has been upgraded. Happy Helming!
NAME: pagopa-fdr-json-to-xml
LAST DEPLOYED: Thu Oct 16 12:38:38 2025
NAMESPACE: fdr
STATUS: deployed
REVISION: 20
TEST SUITE: None
```
```
❯ kubectl get scaledobject pagopa-fdr-json-to-xml-functions -n fdr -o jsonpath='{.metadata.labels.helm\.sh/blueprint-version}'
8.0.2%
```
```
❯ kubectl get pods -n fdr -l app.kubernetes.io/instance=pagopa-fdr-json-to-xml
NAME                                                READY   STATUS    RESTARTS   AGE
pagopa-fdr-json-to-xml-functions-84988b8d86-m2xr8   1/1     Running   0          2m44s
```
```
❯ kubectl get pods,hpa,scaledobject -n fdr -l app.kubernetes.io/instance=pagopa-fdr-json-to-xml
NAME                                                    READY   STATUS    RESTARTS   AGE
pod/pagopa-fdr-json-to-xml-functions-84988b8d86-m2xr8   1/1     Running   0          2m50s

NAME                                                                            REFERENCE                                     TARGETS        MINPODS   MAXPODS   REPLICAS   AGE
horizontalpodautoscaler.autoscaling/keda-hpa-pagopa-fdr-json-to-xml-functions   Deployment/pagopa-fdr-json-to-xml-functions   cpu: 14%/75%   1         1         1          2m49s

NAME                                                    SCALETARGETKIND      SCALETARGETNAME                    MIN   MAX   READY   ACTIVE   FALLBACK   PAUSED    TRIGGERS   AUTHENTICATIONS                    AGE
scaledobject.keda.sh/pagopa-fdr-json-to-xml-functions   apps/v1.Deployment   pagopa-fdr-json-to-xml-functions   1     1     True    True     False      Unknown   cpu        pagopa-fdr-json-to-xml-functions   2m49s
```

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
